### PR TITLE
feat: Add metrics, health checks, and server setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,286 @@
+.PHONY: help build run test lint fmt swagger migrate clean up down logs shell
+
+# Variables
+APP_NAME := config-service
+BINARY_NAME := main
+DOCKER_COMPOSE_FILE := deployments/docker-compose.yml
+MIGRATION_PATH := migrations
+DATABASE_URL := postgres://postgres:postgres@localhost:5432/config_service?sslmode=disable
+
+# Colors for output
+RED := \033[0;31m
+GREEN := \033[0;32m
+YELLOW := \033[0;33m
+BLUE := \033[0;34m
+MAGENTA := \033[0;35m
+CYAN := \033[0;36m
+WHITE := \033[0;37m
+RESET := \033[0m
+
+# Default target
+help: ## Show this help message
+	@echo "$(CYAN)Available commands:$(RESET)"
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make $(GREEN)<target>$(RESET)\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  $(GREEN)%-15s$(RESET) %s\n", $$1, $$2 } /^##@/ { printf "\n$(MAGENTA)%s$(RESET)\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Development
+build: ## Build the application binary
+	@echo "$(BLUE)Building $(APP_NAME)...$(RESET)"
+	go build -ldflags="-s -w" -o bin/$(BINARY_NAME) cmd/server/main.go
+	@echo "$(GREEN)Build completed: bin/$(BINARY_NAME)$(RESET)"
+
+build-docker: ## Build Docker image
+	@echo "$(BLUE)Building Docker image...$(RESET)"
+	docker build -f deployments/Dockerfile -t $(APP_NAME):latest .
+	@echo "$(GREEN)Docker image built: $(APP_NAME):latest$(RESET)"
+
+run: ## Run the application locally
+	@echo "$(BLUE)Running $(APP_NAME)...$(RESET)"
+	go run cmd/server/main.go
+
+run-docker: build-docker ## Run the application in Docker
+	@echo "$(BLUE)Running $(APP_NAME) in Docker...$(RESET)"
+	docker run --rm -p 8080:8080 \
+		-e DATABASE_HOST=host.docker.internal \
+		-e REDIS_HOST=host.docker.internal \
+		-e KAFKA_BROKERS=host.docker.internal:9092 \
+		$(APP_NAME):latest
+
+##@ Infrastructure
+up: ## Start all services with Docker Compose
+	@echo "$(BLUE)Starting all services...$(RESET)"
+	docker-compose -f $(DOCKER_COMPOSE_FILE) up -d
+	@echo "$(GREEN)All services started!$(RESET)"
+	@echo "$(YELLOW)Waiting for services to be ready...$(RESET)"
+	@sleep 10
+	@make status
+
+down: ## Stop all services
+	@echo "$(BLUE)Stopping all services...$(RESET)"
+	docker-compose -f $(DOCKER_COMPOSE_FILE) down
+	@echo "$(GREEN)All services stopped!$(RESET)"
+
+restart: down up ## Restart all services
+
+status: ## Show status of all services
+	@echo "$(CYAN)Service Status:$(RESET)"
+	docker-compose -f $(DOCKER_COMPOSE_FILE) ps
+
+logs: ## Show logs from all services
+	docker-compose -f $(DOCKER_COMPOSE_FILE) logs -f
+
+logs-app: ## Show application logs only
+	docker-compose -f $(DOCKER_COMPOSE_FILE) logs -f config-service
+
+##@ Database
+migrate-up: ## Run database migrations
+	@echo "$(BLUE)Running database migrations...$(RESET)"
+	migrate -path $(MIGRATION_PATH) -database "$(DATABASE_URL)" up
+	@echo "$(GREEN)Migrations completed!$(RESET)"
+
+migrate-down: ## Rollback one migration
+	@echo "$(BLUE)Rolling back one migration...$(RESET)"
+	migrate -path $(MIGRATION_PATH) -database "$(DATABASE_URL)" down 1
+	@echo "$(GREEN)Rollback completed!$(RESET)"
+
+migrate-reset: ## Reset all migrations
+	@echo "$(RED)WARNING: This will reset all migrations!$(RESET)"
+	@read -p "Are you sure? [y/N] " -n 1 -r; \
+	if [[ $REPLY =~ ^[Yy]$ ]]; then \
+		echo "$(BLUE)Resetting migrations...$(RESET)"; \
+		migrate -path $(MIGRATION_PATH) -database "$(DATABASE_URL)" down -all; \
+		echo "$(GREEN)All migrations reset!$(RESET)"; \
+	else \
+		echo "$(YELLOW)Operation cancelled.$(RESET)"; \
+	fi
+
+migrate-version: ## Show current migration version
+	migrate -path $(MIGRATION_PATH) -database "$(DATABASE_URL)" version
+
+migrate-create: ## Create new migration (usage: make migrate-create NAME=create_users_table)
+	@if [ -z "$(NAME)" ]; then \
+		echo "$(RED)Error: NAME is required$(RESET)"; \
+		echo "Usage: make migrate-create NAME=create_users_table"; \
+		exit 1; \
+	fi
+	@echo "$(BLUE)Creating migration: $(NAME)$(RESET)"
+	migrate create -ext sql -dir $(MIGRATION_PATH) -seq $(NAME)
+	@echo "$(GREEN)Migration files created!$(RESET)"
+
+##@ Testing
+test: ## Run all tests
+	@echo "$(BLUE)Running tests...$(RESET)"
+	go test -v -race -cover ./...
+
+test-coverage: ## Run tests with coverage report
+	@echo "$(BLUE)Running tests with coverage...$(RESET)"
+	go test -v -race -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out -o coverage.html
+	@echo "$(GREEN)Coverage report generated: coverage.html$(RESET)"
+
+test-integration: ## Run integration tests
+	@echo "$(BLUE)Running integration tests...$(RESET)"
+	go test -v -tags=integration ./...
+
+benchmark: ## Run benchmarks
+	@echo "$(BLUE)Running benchmarks...$(RESET)"
+	go test -bench=. -benchmem ./...
+
+##@ Code Quality
+lint: ## Run linters
+	@echo "$(BLUE)Running linters...$(RESET)"
+	golangci-lint run
+	@echo "$(GREEN)Linting completed!$(RESET)"
+
+fmt: ## Format code
+	@echo "$(BLUE)Formatting code...$(RESET)"
+	gofmt -s -w .
+	goimports -w .
+	@echo "$(GREEN)Code formatted!$(RESET)"
+
+vet: ## Run go vet
+	@echo "$(BLUE)Running go vet...$(RESET)"
+	go vet ./...
+
+mod-tidy: ## Tidy go modules
+	@echo "$(BLUE)Tidying go modules...$(RESET)"
+	go mod tidy
+	@echo "$(GREEN)Modules tidied!$(RESET)"
+
+##@ Documentation
+swagger: ## Generate Swagger documentation
+	@echo "$(BLUE)Generating Swagger documentation...$(RESET)"
+	swag init -g cmd/server/main.go --output docs/swagger
+	@echo "$(GREEN)Swagger documentation generated!$(RESET)"
+
+docs-serve: ## Serve documentation locally
+	@echo "$(BLUE)Starting documentation server...$(RESET)"
+	@echo "$(CYAN)Swagger UI: http://localhost:8080/swagger/index.html$(RESET)"
+	@make run
+
+##@ Utilities
+shell: ## Open shell in running container
+	docker-compose -f $(DOCKER_COMPOSE_FILE) exec config-service sh
+
+shell-db: ## Open PostgreSQL shell
+	docker-compose -f $(DOCKER_COMPOSE_FILE) exec postgres psql -U postgres -d config_service
+
+shell-redis: ## Open Redis CLI
+	docker-compose -f $(DOCKER_COMPOSE_FILE) exec redis redis-cli
+
+clean: ## Clean build artifacts
+	@echo "$(BLUE)Cleaning build artifacts...$(RESET)"
+	rm -rf bin/
+	rm -f coverage.out coverage.html
+	docker system prune -f
+	@echo "$(GREEN)Clean completed!$(RESET)"
+
+clean-all: clean ## Clean everything including volumes
+	@echo "$(RED)WARNING: This will remove all Docker volumes!$(RESET)"
+	@read -p "Are you sure? [y/N] " -n 1 -r; \
+	if [[ $REPLY =~ ^[Yy]$ ]]; then \
+		echo "$(BLUE)Removing all volumes...$(RESET)"; \
+		docker-compose -f $(DOCKER_COMPOSE_FILE) down -v; \
+		docker volume prune -f; \
+		echo "$(GREEN)All volumes removed!$(RESET)"; \
+	else \
+		echo "$(YELLOW)Operation cancelled.$(RESET)"; \
+	fi
+
+##@ Monitoring
+monitoring-up: ## Start monitoring stack (Prometheus + Grafana)
+	@echo "$(BLUE)Starting monitoring stack...$(RESET)"
+	docker-compose -f $(DOCKER_COMPOSE_FILE) up -d prometheus grafana
+	@echo "$(GREEN)Monitoring stack started!$(RESET)"
+	@echo "$(CYAN)Prometheus: http://localhost:9090$(RESET)"
+	@echo "$(CYAN)Grafana: http://localhost:3000 (admin/admin)$(RESET)"
+
+kafka-topics: ## List Kafka topics
+	docker-compose -f $(DOCKER_COMPOSE_FILE) exec kafka kafka-topics --bootstrap-server localhost:9092 --list
+
+kafka-console-producer: ## Start Kafka console producer
+	docker-compose -f $(DOCKER_COMPOSE_FILE) exec kafka kafka-console-producer --bootstrap-server localhost:9092 --topic config-events
+
+kafka-console-consumer: ## Start Kafka console consumer
+	docker-compose -f $(DOCKER_COMPOSE_FILE) exec kafka kafka-console-consumer --bootstrap-server localhost:9092 --topic config-events --from-beginning
+
+##@ Production
+build-prod: ## Build production binary
+	@echo "$(BLUE)Building production binary...$(RESET)"
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+		-ldflags="-s -w -extldflags '-static'" \
+		-a -installsuffix cgo \
+		-o bin/$(BINARY_NAME)-linux-amd64 \
+		cmd/server/main.go
+	@echo "$(GREEN)Production binary built: bin/$(BINARY_NAME)-linux-amd64$(RESET)"
+
+deploy-staging: build-prod ## Deploy to staging environment
+	@echo "$(BLUE)Deploying to staging...$(RESET)"
+	# Add your staging deployment commands here
+	@echo "$(GREEN)Deployed to staging!$(RESET)"
+
+deploy-prod: build-prod ## Deploy to production environment
+	@echo "$(RED)WARNING: Deploying to production!$(RESET)"
+	@read -p "Are you sure? [y/N] " -n 1 -r; \
+	if [[ $REPLY =~ ^[Yy]$ ]]; then \
+		echo "$(BLUE)Deploying to production...$(RESET)"; \
+		# Add your production deployment commands here; \
+		echo "$(GREEN)Deployed to production!$(RESET)"; \
+	else \
+		echo "$(YELLOW)Deployment cancelled.$(RESET)"; \
+	fi
+
+##@ CI/CD
+ci-test: fmt vet lint test ## Run CI tests locally
+	@echo "$(GREEN)All CI checks passed!$(RESET)"
+
+pre-commit: ci-test swagger ## Run pre-commit checks
+	@echo "$(GREEN)Ready for commit!$(RESET)"
+
+##@ Information
+version: ## Show application version
+	@go run cmd/server/main.go -version 2>/dev/null || echo "Run 'make build' first"
+
+deps: ## Show dependencies
+	@echo "$(CYAN)Go Dependencies:$(RESET)"
+	go list -m all
+
+env: ## Show environment variables
+	@echo "$(CYAN)Environment Variables:$(RESET)"
+	@echo "DATABASE_URL=$(DATABASE_URL)"
+	@echo "MIGRATION_PATH=$(MIGRATION_PATH)"
+	@echo "APP_NAME=$(APP_NAME)"
+
+health: ## Check service health
+	@echo "$(BLUE)Checking service health...$(RESET)"
+	@curl -s http://localhost:8080/health | jq . 2>/dev/null || \
+		echo "$(RED)Service not running or jq not installed$(RESET)"
+
+api-test: ## Test API endpoints
+	@echo "$(BLUE)Testing API endpoints...$(RESET)"
+	@echo "$(CYAN)Health endpoint:$(RESET)"
+	@curl -s http://localhost:8080/health || echo "$(RED)Failed$(RESET)"
+	@echo ""
+	@echo "$(CYAN)Ready endpoint:$(RESET)"
+	@curl -s http://localhost:8080/ready || echo "$(RED)Failed$(RESET)"
+	@echo ""
+	@echo "$(CYAN)Metrics endpoint:$(RESET)"
+	@curl -s http://localhost:8080/metrics | head -5 || echo "$(RED)Failed$(RESET)"
+
+##@ Quick Start
+install-tools: ## Install required development tools
+	@echo "$(BLUE)Installing development tools...$(RESET)"
+	go install github.com/swaggo/swag/cmd/swag@latest
+	go install github.com/golang/mock/mockgen@latest
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.54.2
+	go install golang.org/x/tools/cmd/goimports@latest
+	@echo "$(GREEN)Development tools installed!$(RESET)"
+
+setup: install-tools up migrate-up swagger ## Complete project setup
+	@echo "$(GREEN)Project setup completed!$(RESET)"
+	@echo "$(CYAN)Next steps:$(RESET)"
+	@echo "  - API Documentation: http://localhost:8080/swagger/index.html"
+	@echo "  - Kafka UI: http://localhost:8090"
+	@echo "  - Prometheus: http://localhost:9090"
+	@echo "  - Grafana: http://localhost:3000"
+	@echo "  - Run tests: make test"
+	@echo "  - View logs: make logs-app"

--- a/config-service/cmd/server/main.go
+++ b/config-service/cmd/server/main.go
@@ -1,0 +1,358 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/company/config-service/internal/api/health"
+	"github.com/company/config-service/internal/config"
+	"github.com/company/config-service/internal/database"
+	"github.com/company/config-service/internal/logger"
+	"github.com/company/config-service/pkg/metrics"
+	"github.com/gin-gonic/gin"
+	"github.com/go-redis/redis/v8"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	swaggerFiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
+)
+
+var (
+	version   = "dev"
+	buildTime = "unknown"
+	gitCommit = "unknown"
+)
+
+// @title Config Service API
+// @version 1.0
+// @description A configuration management service for cloud-native applications
+// @termsOfService http://swagger.io/terms/
+
+// @contact.name API Support
+// @contact.url http://www.example.com/support
+// @contact.email support@example.com
+
+// @license.name Apache 2.0
+// @license.url http://www.apache.org/licenses/LICENSE-2.0.html
+
+// @host localhost:8080
+// @BasePath /api/v1
+
+// @securityDefinitions.apikey BearerAuth
+// @in header
+// @name Authorization
+// @description Type "Bearer" followed by a space and JWT token.
+
+func main() {
+	// Load configuration
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Printf("Failed to load configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Initialize logger
+	log := logger.New(logger.Config{
+		Level:  cfg.Logger.Level,
+		Format: cfg.Logger.Format,
+	})
+	logger.SetGlobal(log)
+
+	log.Info().
+		Str("version", version).
+		Str("build_time", buildTime).
+		Str("git_commit", gitCommit).
+		Str("environment", cfg.Server.Environment).
+		Msg("Starting Config Service")
+
+	// Initialize database connection
+	db, err := database.New(cfg.Database, log)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to connect to database")
+	}
+	defer db.Close()
+
+	// Run database migrations
+	migrationRunner, err := database.NewMigrationRunner(db, cfg.Database, log)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to create migration runner")
+	}
+	defer migrationRunner.Close()
+
+	if err := migrationRunner.Up(); err != nil {
+		log.Fatal().Err(err).Msg("Failed to run database migrations")
+	}
+
+	// Initialize Redis client
+	redisClient := redis.NewClient(&redis.Options{
+		Addr:     cfg.Redis.GetRedisAddr(),
+		Password: cfg.Redis.Password,
+		DB:       cfg.Redis.DB,
+	})
+	defer redisClient.Close()
+
+	// Test Redis connection
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	
+	if err := redisClient.Ping(ctx).Err(); err != nil {
+		log.Fatal().Err(err).Msg("Failed to connect to Redis")
+	}
+
+	// Initialize metrics
+	metricsCollector := metrics.New()
+
+	// Set Gin mode based on environment
+	if cfg.Server.Environment == "production" {
+		gin.SetMode(gin.ReleaseMode)
+	}
+
+	// Initialize Gin router
+	router := gin.New()
+
+	// Add middleware
+	router.Use(gin.Recovery())
+	router.Use(metricsCollector.Middleware())
+	router.Use(corsMiddleware())
+	router.Use(requestIDMiddleware())
+	router.Use(loggingMiddleware(log))
+
+	// Health check endpoints (no versioning)
+	healthHandler := health.New(db, redisClient, log, version)
+	router.GET("/health", healthHandler.Health)
+	router.GET("/ready", healthHandler.Readiness)
+	router.GET("/live", healthHandler.Liveness)
+
+	// Metrics endpoint
+	if cfg.Metrics.Enabled {
+		router.GET(cfg.Metrics.Path, gin.WrapH(promhttp.Handler()))
+	}
+
+	// Swagger documentation
+	if cfg.Server.Environment != "production" {
+		router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	}
+
+	// API v1 routes
+	v1 := router.Group("/api/v1")
+	{
+		// TODO: Add your API handlers here
+		v1.GET("/ping", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{
+				"message": "pong",
+				"version": version,
+				"time":    time.Now().Format(time.RFC3339),
+			})
+		})
+	}
+
+	// Create HTTP server
+	server := &http.Server{
+		Addr:         fmt.Sprintf("%s:%s", cfg.Server.Host, cfg.Server.Port),
+		Handler:      router,
+		ReadTimeout:  cfg.Server.ReadTimeout,
+		WriteTimeout: cfg.Server.WriteTimeout,
+		IdleTimeout:  cfg.Server.IdleTimeout,
+	}
+
+	// Start server in a goroutine
+	go func() {
+		log.Info().
+			Str("host", cfg.Server.Host).
+			Str("port", cfg.Server.Port).
+			Msg("Starting HTTP server")
+
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatal().Err(err).Msg("Failed to start server")
+		}
+	}()
+
+	// Start metrics updater in a goroutine
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				stats := db.Stats()
+				metricsCollector.UpdateDBConnections(
+					stats.OpenConnections,
+					stats.Idle,
+					stats.InUse,
+				)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Wait for interrupt signal to gracefully shutdown the server
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+
+	log.Info().Msg("Shutting down server...")
+
+	// Create a context with timeout for graceful shutdown
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer shutdownCancel()
+
+	// Gracefully shutdown the server
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		log.Fatal().Err(err).Msg("Server forced to shutdown")
+	}
+
+	log.Info().Msg("Server exited")
+}
+
+// corsMiddleware adds CORS headers
+func corsMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("Access-Control-Allow-Origin", "*")
+		c.Header("Access-Control-Allow-Credentials", "true")
+		c.Header("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
+		c.Header("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT, DELETE, PATCH")
+
+		if c.Request.Method == "OPTIONS" {
+			c.AbortWithStatus(204)
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// requestIDMiddleware adds a unique request ID to each request
+func requestIDMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		requestID := c.GetHeader("X-Request-ID")
+		if requestID == "" {
+			requestID = generateRequestID()
+		}
+		
+		c.Header("X-Request-ID", requestID)
+		c.Set("request_id", requestID)
+		c.Next()
+	}
+}
+
+// loggingMiddleware logs HTTP requests
+func loggingMiddleware(log *logger.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		path := c.Request.URL.Path
+		raw := c.Request.URL.RawQuery
+		requestID, _ := c.Get("request_id")
+
+		// Process request
+		c.Next()
+
+		// Log request
+		latency := time.Since(start)
+		statusCode := c.Writer.Status()
+		clientIP := c.ClientIP()
+		method := c.Request.Method
+		userAgent := c.Request.UserAgent()
+
+		if raw != "" {
+			path = path + "?" + raw
+		}
+
+		log.InfoWithFields("HTTP request", map[string]interface{}{
+			"request_id":   requestID,
+			"status":       statusCode,
+			"latency":      latency.String(),
+			"client_ip":    clientIP,
+			"method":       method,
+			"path":         path,
+			"user_agent":   userAgent,
+			"body_size":    c.Writer.Size(),
+		})
+	}
+}
+
+// generateRequestID generates a unique request ID
+func generateRequestID() string {
+	return fmt.Sprintf("%d", time.Now().UnixNano())
+}
+
+// pkg/errors/errors.go
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Common application errors
+var (
+	ErrNotFound          = errors.New("resource not found")
+	ErrAlreadyExists     = errors.New("resource already exists")
+	ErrInvalidInput      = errors.New("invalid input")
+	ErrUnauthorized      = errors.New("unauthorized")
+	ErrForbidden         = errors.New("forbidden")
+	ErrInternalServer    = errors.New("internal server error")
+	ErrServiceUnavailable = errors.New("service unavailable")
+)
+
+// AppError represents an application error with additional context
+type AppError struct {
+	Type    string            `json:"type"`
+	Message string            `json:"message"`
+	Details map[string]string `json:"details,omitempty"`
+	Err     error             `json:"-"`
+}
+
+// Error implements the error interface
+func (e *AppError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.Err)
+	}
+	return e.Message
+}
+
+// Unwrap returns the underlying error
+func (e *AppError) Unwrap() error {
+	return e.Err
+}
+
+// NewAppError creates a new application error
+func NewAppError(errorType, message string, err error) *AppError {
+	return &AppError{
+		Type:    errorType,
+		Message: message,
+		Err:     err,
+	}
+}
+
+// NewValidationError creates a validation error with field details
+func NewValidationError(fieldErrors map[string]string) *AppError {
+	return &AppError{
+		Type:    "validation_error",
+		Message: "Validation failed",
+		Details: fieldErrors,
+	}
+}
+
+// NewNotFoundError creates a not found error
+func NewNotFoundError(resource string) *AppError {
+	return &AppError{
+		Type:    "not_found",
+		Message: fmt.Sprintf("%s not found", resource),
+		Err:     ErrNotFound,
+	}
+}
+
+// NewConflictError creates a conflict error
+func NewConflictError(resource string) *AppError {
+	return &AppError{
+		Type:    "conflict",
+		Message: fmt.Sprintf("%s already exists", resource),
+		Err:     ErrAlreadyExists,
+	}
+}

--- a/config-service/internal/api/health/handler.go
+++ b/config-service/internal/api/health/handler.go
@@ -1,0 +1,171 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/company/config-service/internal/database"
+	"github.com/company/config-service/internal/logger"
+	"github.com/company/config-service/internal/model"
+	"github.com/gin-gonic/gin"
+	"github.com/go-redis/redis/v8"
+)
+
+// Handler handles health check endpoints
+type Handler struct {
+	db     *database.Connection
+	redis  *redis.Client
+	logger *logger.Logger
+	version string
+}
+
+// New creates a new health handler
+func New(db *database.Connection, redis *redis.Client, log *logger.Logger, version string) *Handler {
+	return &Handler{
+		db:      db,
+		redis:   redis,
+		logger:  log,
+		version: version,
+	}
+}
+
+// Health godoc
+// @Summary Health check endpoint
+// @Description Returns the health status of the service and its dependencies
+// @Tags health
+// @Accept json
+// @Produce json
+// @Success 200 {object} model.HealthResponse
+// @Failure 503 {object} model.ErrorResponse
+// @Router /health [get]
+func (h *Handler) Health(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	services := make(map[string]model.ServiceHealthInfo)
+	overall := "healthy"
+
+	// Check database
+	dbHealth := h.checkDatabase(ctx)
+	services["database"] = dbHealth
+	if dbHealth.Status != "healthy" {
+		overall = "unhealthy"
+	}
+
+	// Check Redis
+	redisHealth := h.checkRedis(ctx)
+	services["redis"] = redisHealth
+	if redisHealth.Status != "healthy" {
+		overall = "unhealthy"
+	}
+
+	response := model.HealthResponse{
+		Status:   overall,
+		Version:  h.version,
+		Services: services,
+	}
+
+	if overall == "healthy" {
+		c.JSON(http.StatusOK, response)
+	} else {
+		c.JSON(http.StatusServiceUnavailable, response)
+	}
+}
+
+// Readiness godoc
+// @Summary Readiness check endpoint
+// @Description Returns readiness status for Kubernetes readiness probe
+// @Tags health
+// @Accept json
+// @Produce json
+// @Success 200 {object} model.SuccessResponse
+// @Failure 503 {object} model.ErrorResponse
+// @Router /ready [get]
+func (h *Handler) Readiness(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
+	defer cancel()
+
+	// Check if database is ready
+	if err := h.db.HealthCheck(); err != nil {
+		h.logger.Error().Err(err).Msg("Database readiness check failed")
+		c.JSON(http.StatusServiceUnavailable, model.ErrorResponse{
+			Error:   "service_not_ready",
+			Message: "Database is not ready",
+		})
+		return
+	}
+
+	// Check if Redis is ready
+	if err := h.redis.Ping(ctx).Err(); err != nil {
+		h.logger.Error().Err(err).Msg("Redis readiness check failed")
+		c.JSON(http.StatusServiceUnavailable, model.ErrorResponse{
+			Error:   "service_not_ready",
+			Message: "Redis is not ready",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, model.SuccessResponse{
+		Message: "Service is ready",
+	})
+}
+
+// Liveness godoc
+// @Summary Liveness check endpoint
+// @Description Returns liveness status for Kubernetes liveness probe
+// @Tags health
+// @Accept json
+// @Produce json
+// @Success 200 {object} model.SuccessResponse
+// @Router /live [get]
+func (h *Handler) Liveness(c *gin.Context) {
+	c.JSON(http.StatusOK, model.SuccessResponse{
+		Message: "Service is alive",
+	})
+}
+
+func (h *Handler) checkDatabase(ctx context.Context) model.ServiceHealthInfo {
+	start := time.Now()
+	
+	err := h.db.HealthCheck()
+	latency := time.Since(start)
+
+	info := model.ServiceHealthInfo{
+		LastCheck: time.Now().Format(time.RFC3339),
+		Latency:   latency.String(),
+	}
+
+	if err != nil {
+		info.Status = "unhealthy"
+		info.Message = err.Error()
+	} else {
+		info.Status = "healthy"
+		info.Message = "Database connection is healthy"
+	}
+
+	return info
+}
+
+func (h *Handler) checkRedis(ctx context.Context) model.ServiceHealthInfo {
+	start := time.Now()
+	
+	err := h.redis.Ping(ctx).Err()
+	latency := time.Since(start)
+
+	info := model.ServiceHealthInfo{
+		LastCheck: time.Now().Format(time.RFC3339),
+		Latency:   latency.String(),
+	}
+
+	if err != nil {
+		info.Status = "unhealthy"
+		info.Message = err.Error()
+	} else {
+		info.Status = "healthy"
+		info.Message = "Redis connection is healthy"
+	}
+
+	return info
+}

--- a/config-service/pkg/metrics/metrics.go
+++ b/config-service/pkg/metrics/metrics.go
@@ -1,0 +1,145 @@
+package metrics
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics holds all Prometheus metrics
+type Metrics struct {
+	requestsTotal     *prometheus.CounterVec
+	requestDuration   *prometheus.HistogramVec
+	responseSize      *prometheus.HistogramVec
+	activeConnections prometheus.Gauge
+	dbConnections     *prometheus.GaugeVec
+}
+
+// New creates a new metrics instance
+func New() *Metrics {
+	return &Metrics{
+		requestsTotal: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "http_requests_total",
+				Help: "Total number of HTTP requests",
+			},
+			[]string{"method", "endpoint", "status_code"},
+		),
+		requestDuration: promauto.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "http_request_duration_seconds",
+				Help:    "Duration of HTTP requests in seconds",
+				Buckets: prometheus.DefBuckets,
+			},
+			[]string{"method", "endpoint", "status_code"},
+		),
+		responseSize: promauto.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "http_response_size_bytes",
+				Help:    "Size of HTTP responses in bytes",
+				Buckets: []float64{200, 500, 900, 1500, 3000, 6000, 12000, 24000, 48000, 96000},
+			},
+			[]string{"method", "endpoint"},
+		),
+		activeConnections: promauto.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "http_active_connections",
+				Help: "Number of active HTTP connections",
+			},
+		),
+		dbConnections: promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "database_connections",
+				Help: "Number of database connections by state",
+			},
+			[]string{"state"},
+		),
+	}
+}
+
+// Middleware returns a Gin middleware for collecting HTTP metrics
+func (m *Metrics) Middleware() gin.HandlerFunc {
+	return gin.HandlerFunc(func(c *gin.Context) {
+		start := time.Now()
+		
+		// Increment active connections
+		m.activeConnections.Inc()
+		defer m.activeConnections.Dec()
+
+		// Process request
+		c.Next()
+
+		// Calculate metrics
+		duration := time.Since(start).Seconds()
+		statusCode := strconv.Itoa(c.Writer.Status())
+		method := c.Request.Method
+		endpoint := c.FullPath()
+		
+		// If no route matched, use the raw path
+		if endpoint == "" {
+			endpoint = c.Request.URL.Path
+		}
+
+		// Record metrics
+		m.requestsTotal.WithLabelValues(method, endpoint, statusCode).Inc()
+		m.requestDuration.WithLabelValues(method, endpoint, statusCode).Observe(duration)
+		m.responseSize.WithLabelValues(method, endpoint).Observe(float64(c.Writer.Size()))
+	})
+}
+
+// UpdateDBConnections updates database connection metrics
+func (m *Metrics) UpdateDBConnections(open, idle, inUse int) {
+	m.dbConnections.WithLabelValues("open").Set(float64(open))
+	m.dbConnections.WithLabelValues("idle").Set(float64(idle))
+	m.dbConnections.WithLabelValues("in_use").Set(float64(inUse))
+}
+
+// Custom metrics for business logic
+var (
+	ConfigTemplatesTotal = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "config_templates_total",
+			Help: "Total number of configuration templates",
+		},
+		[]string{"environment", "format", "active"},
+	)
+
+	ConfigTemplateOperations = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "config_template_operations_total",
+			Help: "Total number of configuration template operations",
+		},
+		[]string{"operation", "environment", "status"},
+	)
+
+	ConfigTemplateSize = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "config_template_size_bytes",
+			Help:    "Size of configuration templates in bytes",
+			Buckets: []float64{100, 500, 1000, 5000, 10000, 50000, 100000},
+		},
+		[]string{"environment", "format"},
+	)
+)
+
+// RecordTemplateOperation records a template operation metric
+func RecordTemplateOperation(operation, environment, status string) {
+	ConfigTemplateOperations.WithLabelValues(operation, environment, status).Inc()
+}
+
+// RecordTemplateSize records a template size metric
+func RecordTemplateSize(environment, format string, size int) {
+	ConfigTemplateSize.WithLabelValues(environment, format).Observe(float64(size))
+}
+
+// UpdateTemplateCount updates template count metrics
+func UpdateTemplateCount(environment, format string, active bool, count int) {
+	activeStr := "false"
+	if active {
+		activeStr = "true"
+	}
+	ConfigTemplatesTotal.WithLabelValues(environment, format, activeStr).Set(float64(count))
+}


### PR DESCRIPTION
- Add Prometheus-based metrics collection with HTTP middleware and custom business metrics (e.g., template operations, sizes).
- Implement health, liveness, and readiness endpoints for service and dependency health monitoring.
- Introduce `main.go` to initialize server, database, Redis, and metrics updates.
- Enhance `Makefile` with commands for builds, migrations, testing, and monitoring setup.